### PR TITLE
fix: stopwatch buttons color

### DIFF
--- a/dist/nord-polar-night/nord-polar-night.css
+++ b/dist/nord-polar-night/nord-polar-night.css
@@ -12,6 +12,7 @@ body.isWeb.isEnabledBackgroundGradient .page-wrapper {
   color: var(--color-foreground) !important;
 }
 
+/*HACK: add !important to be able to use palette-accent-500*/
 :root {
   --color-white: #ffffff;
   --color-foreground: #eceff4;
@@ -30,7 +31,7 @@ body.isWeb.isEnabledBackgroundGradient .page-wrapper {
   --color-inputs-focused: var(--color-background-task);
   --color-purple: #b48ead;
   --color-accent: var(--color-purple);
-  --palette-accent-500: var(--color-accent);
+  --palette-accent-500: var(--color-accent) !important;
   --color-info-bar: var(--color-tag-title);
   --color-background: #3b4252;
   --color-foreground: #eceff4;
@@ -57,6 +58,8 @@ body.isWeb.isEnabledBackgroundGradient .page-wrapper {
   --color-background-notes: rgb(62 71 87);
   --color-background-inline-markdown: #373e4d;
   --color-background-button-shadow: rgb(97 130 188);
+  --mdc-fab-small-container-color: var(--color-accent);
+  --mat-sys-primary-container: var(--color-accent);
 }
 
 /** {*/
@@ -96,13 +99,8 @@ body.isDarkTheme :focus > .inner-wrapper > .box,
 body.isDarkTheme.isDisableBackgroundGradient :focus .input-item,
 body.isDarkTheme.isDisableBackgroundGradient :focus .mat-expansion-panel,
 body.isDarkTheme.isDisableBackgroundGradient :focus > .inner-wrapper > .box,
-body.isDarkTheme.isDisableBackgroundGradient.isNoTouchOnly
-  :focus
-  > .inner-wrapper
-  > .box,
-body.isDarkTheme.isDisableBackgroundGradient.isNoTouchOnly:focus
-  > .inner-wrapper
-  > .box,
+body.isDarkTheme.isDisableBackgroundGradient.isNoTouchOnly :focus > .inner-wrapper > .box,
+body.isDarkTheme.isDisableBackgroundGradient.isNoTouchOnly:focus > .inner-wrapper > .box,
 body.isDarkTheme.isNoTouchOnly :focus > .inner-wrapper > .box,
 body.isDarkTheme.isNoTouchOnly:focus > .inner-wrapper > .box,
 body.isDisableBackgroundGradient :focus .input-item,
@@ -125,33 +123,21 @@ body.isLightTheme.isDisableBackgroundGradient.isNoTouchOnly
   :focus
   > .inner-wrapper
   > .box,
-body.isLightTheme.isDisableBackgroundGradient.isNoTouchOnly:focus
-  > .inner-wrapper
-  > .box,
+body.isLightTheme.isDisableBackgroundGradient.isNoTouchOnly:focus > .inner-wrapper > .box,
 body.isLightTheme.isNoTouchOnly :focus > .inner-wrapper > .box,
 body.isLightTheme.isNoTouchOnly:focus > .inner-wrapper > .box,
 body.isMac.isEnabledBackgroundGradient :focus .input-item,
 body.isMac.isEnabledBackgroundGradient :focus .mat-expansion-panel,
 body.isMac.isEnabledBackgroundGradient :focus > .inner-wrapper > .box,
-body.isMac.isEnabledBackgroundGradient.isNoTouchOnly
-  :focus
-  > .inner-wrapper
-  > .box,
-body.isMac.isEnabledBackgroundGradient.isNoTouchOnly:focus
-  > .inner-wrapper
-  > .box,
+body.isMac.isEnabledBackgroundGradient.isNoTouchOnly :focus > .inner-wrapper > .box,
+body.isMac.isEnabledBackgroundGradient.isNoTouchOnly:focus > .inner-wrapper > .box,
 body.isNoTouchOnly :focus > .inner-wrapper > .box,
 body.isNoTouchOnly:focus > .inner-wrapper > .box,
 body.isWeb.isEnabledBackgroundGradient :focus .input-item,
 body.isWeb.isEnabledBackgroundGradient :focus .mat-expansion-panel,
 body.isWeb.isEnabledBackgroundGradient :focus > .inner-wrapper > .box,
-body.isWeb.isEnabledBackgroundGradient.isNoTouchOnly
-  :focus
-  > .inner-wrapper
-  > .box,
-body.isWeb.isEnabledBackgroundGradient.isNoTouchOnly:focus
-  > .inner-wrapper
-  > .box {
+body.isWeb.isEnabledBackgroundGradient.isNoTouchOnly :focus > .inner-wrapper > .box,
+body.isWeb.isEnabledBackgroundGradient.isNoTouchOnly:focus > .inner-wrapper > .box {
   border-color: var(--color-accent) !important;
 }
 body .bg-accent,
@@ -207,9 +193,7 @@ body.isDarkTheme .tag.isActiveContext .tag-color:not([style]),
 body.isDarkTheme .tag.isActiveRoute::before:not([style]),
 body.isDarkTheme .tag:hover .project-color:not([style]),
 body.isDarkTheme .tag:hover .tag-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .project
-  .project-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .project .project-color:not([style]),
 body.isDarkTheme.isDisableBackgroundGradient .project .tag-color:not([style]),
 body.isDarkTheme.isDisableBackgroundGradient
   .project.isActiveContext
@@ -217,20 +201,11 @@ body.isDarkTheme.isDisableBackgroundGradient
 body.isDarkTheme.isDisableBackgroundGradient
   .project.isActiveContext
   .tag-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .project.isActiveRoute::before:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .project:hover
-  .project-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .project:hover
-  .tag-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .route-link
-  .project-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .route-link
-  .tag-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .project.isActiveRoute::before:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .project:hover .project-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .project:hover .tag-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .route-link .project-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .route-link .tag-color:not([style]),
 body.isDarkTheme.isDisableBackgroundGradient
   .route-link.isActiveContext
   .project-color:not([style]),
@@ -242,81 +217,54 @@ body.isDarkTheme.isDisableBackgroundGradient
 body.isDarkTheme.isDisableBackgroundGradient
   .route-link:hover
   .project-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .route-link:hover
-  .tag-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .route-link:hover .tag-color:not([style]),
 body.isDarkTheme.isDisableBackgroundGradient .tag .project-color:not([style]),
 body.isDarkTheme.isDisableBackgroundGradient .tag .tag-color:not([style]),
 body.isDarkTheme.isDisableBackgroundGradient
   .tag.isActiveContext
   .project-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .tag.isActiveContext
-  .tag-color:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .tag.isActiveRoute::before:not([style]),
-body.isDarkTheme.isDisableBackgroundGradient
-  .tag:hover
-  .project-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .tag.isActiveContext .tag-color:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .tag.isActiveRoute::before:not([style]),
+body.isDarkTheme.isDisableBackgroundGradient .tag:hover .project-color:not([style]),
 body.isDarkTheme.isDisableBackgroundGradient .tag:hover .tag-color:not([style]),
 body.isDisableBackgroundGradient .project .project-color:not([style]),
 body.isDisableBackgroundGradient .project .tag-color:not([style]),
-body.isDisableBackgroundGradient
-  .project.isActiveContext
-  .project-color:not([style]),
-body.isDisableBackgroundGradient
-  .project.isActiveContext
-  .tag-color:not([style]),
+body.isDisableBackgroundGradient .project.isActiveContext .project-color:not([style]),
+body.isDisableBackgroundGradient .project.isActiveContext .tag-color:not([style]),
 body.isDisableBackgroundGradient .project.isActiveRoute::before:not([style]),
 body.isDisableBackgroundGradient .project:hover .project-color:not([style]),
 body.isDisableBackgroundGradient .project:hover .tag-color:not([style]),
 body.isDisableBackgroundGradient .route-link .project-color:not([style]),
 body.isDisableBackgroundGradient .route-link .tag-color:not([style]),
-body.isDisableBackgroundGradient
-  .route-link.isActiveContext
-  .project-color:not([style]),
-body.isDisableBackgroundGradient
-  .route-link.isActiveContext
-  .tag-color:not([style]),
+body.isDisableBackgroundGradient .route-link.isActiveContext .project-color:not([style]),
+body.isDisableBackgroundGradient .route-link.isActiveContext .tag-color:not([style]),
 body.isDisableBackgroundGradient .route-link.isActiveRoute::before:not([style]),
 body.isDisableBackgroundGradient .route-link:hover .project-color:not([style]),
 body.isDisableBackgroundGradient .route-link:hover .tag-color:not([style]),
 body.isDisableBackgroundGradient .tag .project-color:not([style]),
 body.isDisableBackgroundGradient .tag .tag-color:not([style]),
-body.isDisableBackgroundGradient
-  .tag.isActiveContext
-  .project-color:not([style]),
+body.isDisableBackgroundGradient .tag.isActiveContext .project-color:not([style]),
 body.isDisableBackgroundGradient .tag.isActiveContext .tag-color:not([style]),
 body.isDisableBackgroundGradient .tag.isActiveRoute::before:not([style]),
 body.isDisableBackgroundGradient .tag:hover .project-color:not([style]),
 body.isDisableBackgroundGradient .tag:hover .tag-color:not([style]),
 body.isEnabledBackgroundGradient .project .project-color:not([style]),
 body.isEnabledBackgroundGradient .project .tag-color:not([style]),
-body.isEnabledBackgroundGradient
-  .project.isActiveContext
-  .project-color:not([style]),
-body.isEnabledBackgroundGradient
-  .project.isActiveContext
-  .tag-color:not([style]),
+body.isEnabledBackgroundGradient .project.isActiveContext .project-color:not([style]),
+body.isEnabledBackgroundGradient .project.isActiveContext .tag-color:not([style]),
 body.isEnabledBackgroundGradient .project.isActiveRoute::before:not([style]),
 body.isEnabledBackgroundGradient .project:hover .project-color:not([style]),
 body.isEnabledBackgroundGradient .project:hover .tag-color:not([style]),
 body.isEnabledBackgroundGradient .route-link .project-color:not([style]),
 body.isEnabledBackgroundGradient .route-link .tag-color:not([style]),
-body.isEnabledBackgroundGradient
-  .route-link.isActiveContext
-  .project-color:not([style]),
-body.isEnabledBackgroundGradient
-  .route-link.isActiveContext
-  .tag-color:not([style]),
+body.isEnabledBackgroundGradient .route-link.isActiveContext .project-color:not([style]),
+body.isEnabledBackgroundGradient .route-link.isActiveContext .tag-color:not([style]),
 body.isEnabledBackgroundGradient .route-link.isActiveRoute::before:not([style]),
 body.isEnabledBackgroundGradient .route-link:hover .project-color:not([style]),
 body.isEnabledBackgroundGradient .route-link:hover .tag-color:not([style]),
 body.isEnabledBackgroundGradient .tag .project-color:not([style]),
 body.isEnabledBackgroundGradient .tag .tag-color:not([style]),
-body.isEnabledBackgroundGradient
-  .tag.isActiveContext
-  .project-color:not([style]),
+body.isEnabledBackgroundGradient .tag.isActiveContext .project-color:not([style]),
 body.isEnabledBackgroundGradient .tag.isActiveContext .tag-color:not([style]),
 body.isEnabledBackgroundGradient .tag.isActiveRoute::before:not([style]),
 body.isEnabledBackgroundGradient .tag:hover .project-color:not([style]),
@@ -342,9 +290,7 @@ body.isLightTheme .tag.isActiveContext .tag-color:not([style]),
 body.isLightTheme .tag.isActiveRoute::before:not([style]),
 body.isLightTheme .tag:hover .project-color:not([style]),
 body.isLightTheme .tag:hover .tag-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .project
-  .project-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .project .project-color:not([style]),
 body.isLightTheme.isDisableBackgroundGradient .project .tag-color:not([style]),
 body.isLightTheme.isDisableBackgroundGradient
   .project.isActiveContext
@@ -352,20 +298,11 @@ body.isLightTheme.isDisableBackgroundGradient
 body.isLightTheme.isDisableBackgroundGradient
   .project.isActiveContext
   .tag-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .project.isActiveRoute::before:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .project:hover
-  .project-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .project:hover
-  .tag-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .route-link
-  .project-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .route-link
-  .tag-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .project.isActiveRoute::before:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .project:hover .project-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .project:hover .tag-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .route-link .project-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .route-link .tag-color:not([style]),
 body.isLightTheme.isDisableBackgroundGradient
   .route-link.isActiveContext
   .project-color:not([style]),
@@ -377,9 +314,7 @@ body.isLightTheme.isDisableBackgroundGradient
 body.isLightTheme.isDisableBackgroundGradient
   .route-link:hover
   .project-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .route-link:hover
-  .tag-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .route-link:hover .tag-color:not([style]),
 body.isLightTheme.isDisableBackgroundGradient .tag .project-color:not([style]),
 body.isLightTheme.isDisableBackgroundGradient .tag .tag-color:not([style]),
 body.isLightTheme.isDisableBackgroundGradient
@@ -388,27 +323,17 @@ body.isLightTheme.isDisableBackgroundGradient
 body.isLightTheme.isDisableBackgroundGradient
   .tag.isActiveContext
   .tag-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .tag.isActiveRoute::before:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .tag:hover
-  .project-color:not([style]),
-body.isLightTheme.isDisableBackgroundGradient
-  .tag:hover
-  .tag-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .tag.isActiveRoute::before:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .tag:hover .project-color:not([style]),
+body.isLightTheme.isDisableBackgroundGradient .tag:hover .tag-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .project .project-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .project .tag-color:not([style]),
 body.isMac.isEnabledBackgroundGradient
   .project.isActiveContext
   .project-color:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .project.isActiveContext
-  .tag-color:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .project.isActiveRoute::before:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .project:hover
-  .project-color:not([style]),
+body.isMac.isEnabledBackgroundGradient .project.isActiveContext .tag-color:not([style]),
+body.isMac.isEnabledBackgroundGradient .project.isActiveRoute::before:not([style]),
+body.isMac.isEnabledBackgroundGradient .project:hover .project-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .project:hover .tag-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .route-link .project-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .route-link .tag-color:not([style]),
@@ -418,22 +343,13 @@ body.isMac.isEnabledBackgroundGradient
 body.isMac.isEnabledBackgroundGradient
   .route-link.isActiveContext
   .tag-color:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .route-link.isActiveRoute::before:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .route-link:hover
-  .project-color:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .route-link:hover
-  .tag-color:not([style]),
+body.isMac.isEnabledBackgroundGradient .route-link.isActiveRoute::before:not([style]),
+body.isMac.isEnabledBackgroundGradient .route-link:hover .project-color:not([style]),
+body.isMac.isEnabledBackgroundGradient .route-link:hover .tag-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .tag .project-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .tag .tag-color:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .tag.isActiveContext
-  .project-color:not([style]),
-body.isMac.isEnabledBackgroundGradient
-  .tag.isActiveContext
-  .tag-color:not([style]),
+body.isMac.isEnabledBackgroundGradient .tag.isActiveContext .project-color:not([style]),
+body.isMac.isEnabledBackgroundGradient .tag.isActiveContext .tag-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .tag.isActiveRoute::before:not([style]),
 body.isMac.isEnabledBackgroundGradient .tag:hover .project-color:not([style]),
 body.isMac.isEnabledBackgroundGradient .tag:hover .tag-color:not([style]),
@@ -442,14 +358,9 @@ body.isWeb.isEnabledBackgroundGradient .project .tag-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient
   .project.isActiveContext
   .project-color:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .project.isActiveContext
-  .tag-color:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .project.isActiveRoute::before:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .project:hover
-  .project-color:not([style]),
+body.isWeb.isEnabledBackgroundGradient .project.isActiveContext .tag-color:not([style]),
+body.isWeb.isEnabledBackgroundGradient .project.isActiveRoute::before:not([style]),
+body.isWeb.isEnabledBackgroundGradient .project:hover .project-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient .project:hover .tag-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient .route-link .project-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient .route-link .tag-color:not([style]),
@@ -459,22 +370,13 @@ body.isWeb.isEnabledBackgroundGradient
 body.isWeb.isEnabledBackgroundGradient
   .route-link.isActiveContext
   .tag-color:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .route-link.isActiveRoute::before:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .route-link:hover
-  .project-color:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .route-link:hover
-  .tag-color:not([style]),
+body.isWeb.isEnabledBackgroundGradient .route-link.isActiveRoute::before:not([style]),
+body.isWeb.isEnabledBackgroundGradient .route-link:hover .project-color:not([style]),
+body.isWeb.isEnabledBackgroundGradient .route-link:hover .tag-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient .tag .project-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient .tag .tag-color:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .tag.isActiveContext
-  .project-color:not([style]),
-body.isWeb.isEnabledBackgroundGradient
-  .tag.isActiveContext
-  .tag-color:not([style]),
+body.isWeb.isEnabledBackgroundGradient .tag.isActiveContext .project-color:not([style]),
+body.isWeb.isEnabledBackgroundGradient .tag.isActiveContext .tag-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient .tag.isActiveRoute::before:not([style]),
 body.isWeb.isEnabledBackgroundGradient .tag:hover .project-color:not([style]),
 body.isWeb.isEnabledBackgroundGradient .tag:hover .tag-color:not([style]) {
@@ -488,10 +390,7 @@ body .mat-step-header .mat-step-icon-selected,
 body .mat-step-header .mat-step-icon-state-done,
 body .mat-step-header .mat-step-icon-state-edit,
 body.isDarkTheme .bg-primary,
-body.isDarkTheme
-  .mat-focused
-  .mat-form-field-appearance-legacy
-  .mat-form-field-underline,
+body.isDarkTheme .mat-focused .mat-form-field-appearance-legacy .mat-form-field-underline,
 body.isDarkTheme .mat-form-field-appearance-legacy .mat-form-field-underline,
 body.isDarkTheme .mat-form-field-underline,
 body.isDarkTheme .mat-step-header .mat-step-icon-selected,
@@ -506,15 +405,9 @@ body.isDarkTheme.isDisableBackgroundGradient
   .mat-form-field-appearance-legacy
   .mat-form-field-underline,
 body.isDarkTheme.isDisableBackgroundGradient .mat-form-field-underline,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-selected,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-done,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-edit,
+body.isDarkTheme.isDisableBackgroundGradient .mat-step-header .mat-step-icon-selected,
+body.isDarkTheme.isDisableBackgroundGradient .mat-step-header .mat-step-icon-state-done,
+body.isDarkTheme.isDisableBackgroundGradient .mat-step-header .mat-step-icon-state-edit,
 body.isDisableBackgroundGradient .bg-primary,
 body.isDisableBackgroundGradient
   .mat-focused
@@ -558,15 +451,9 @@ body.isLightTheme.isDisableBackgroundGradient
   .mat-form-field-appearance-legacy
   .mat-form-field-underline,
 body.isLightTheme.isDisableBackgroundGradient .mat-form-field-underline,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-selected,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-done,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-edit,
+body.isLightTheme.isDisableBackgroundGradient .mat-step-header .mat-step-icon-selected,
+body.isLightTheme.isDisableBackgroundGradient .mat-step-header .mat-step-icon-state-done,
+body.isLightTheme.isDisableBackgroundGradient .mat-step-header .mat-step-icon-state-edit,
 body.isMac.isEnabledBackgroundGradient .bg-primary,
 body.isMac.isEnabledBackgroundGradient
   .mat-focused
@@ -577,12 +464,8 @@ body.isMac.isEnabledBackgroundGradient
   .mat-form-field-underline,
 body.isMac.isEnabledBackgroundGradient .mat-form-field-underline,
 body.isMac.isEnabledBackgroundGradient .mat-step-header .mat-step-icon-selected,
-body.isMac.isEnabledBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-done,
-body.isMac.isEnabledBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-edit,
+body.isMac.isEnabledBackgroundGradient .mat-step-header .mat-step-icon-state-done,
+body.isMac.isEnabledBackgroundGradient .mat-step-header .mat-step-icon-state-edit,
 body.isWeb.isEnabledBackgroundGradient .bg-primary,
 body.isWeb.isEnabledBackgroundGradient
   .mat-focused
@@ -593,12 +476,8 @@ body.isWeb.isEnabledBackgroundGradient
   .mat-form-field-underline,
 body.isWeb.isEnabledBackgroundGradient .mat-form-field-underline,
 body.isWeb.isEnabledBackgroundGradient .mat-step-header .mat-step-icon-selected,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-done,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-step-header
-  .mat-step-icon-state-edit {
+body.isWeb.isEnabledBackgroundGradient .mat-step-header .mat-step-icon-state-done,
+body.isWeb.isEnabledBackgroundGradient .mat-step-header .mat-step-icon-state-edit {
   background: var(--color-accent) !important;
 }
 body .mat-drawer-container,
@@ -623,15 +502,11 @@ body.isWeb.isEnabledBackgroundGradient button {
 }
 body .mat-drawer-content .content-wrapper,
 body.isDarkTheme .mat-drawer-content .content-wrapper,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-drawer-content
-  .content-wrapper,
+body.isDarkTheme.isDisableBackgroundGradient .mat-drawer-content .content-wrapper,
 body.isDisableBackgroundGradient .mat-drawer-content .content-wrapper,
 body.isEnabledBackgroundGradient .mat-drawer-content .content-wrapper,
 body.isLightTheme .mat-drawer-content .content-wrapper,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-drawer-content
-  .content-wrapper,
+body.isLightTheme.isDisableBackgroundGradient .mat-drawer-content .content-wrapper,
 body.isMac.isEnabledBackgroundGradient .mat-drawer-content .content-wrapper,
 body.isWeb.isEnabledBackgroundGradient .mat-drawer-content .content-wrapper {
   background-color: var(--color-background-banner) !important;
@@ -903,9 +778,7 @@ body.isDarkTheme .mat-sidenav,
 body.isDarkTheme .mat-sidenav:focus .mat-drawer-side,
 body.isDarkTheme.isDisableBackgroundGradient .mat-drawer-side,
 body.isDarkTheme.isDisableBackgroundGradient .mat-sidenav,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-sidenav:focus
-  .mat-drawer-side,
+body.isDarkTheme.isDisableBackgroundGradient .mat-sidenav:focus .mat-drawer-side,
 body.isDisableBackgroundGradient .mat-drawer-side,
 body.isDisableBackgroundGradient .mat-sidenav,
 body.isDisableBackgroundGradient .mat-sidenav:focus .mat-drawer-side,
@@ -917,9 +790,7 @@ body.isLightTheme .mat-sidenav,
 body.isLightTheme .mat-sidenav:focus .mat-drawer-side,
 body.isLightTheme.isDisableBackgroundGradient .mat-drawer-side,
 body.isLightTheme.isDisableBackgroundGradient .mat-sidenav,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-sidenav:focus
-  .mat-drawer-side,
+body.isLightTheme.isDisableBackgroundGradient .mat-sidenav:focus .mat-drawer-side,
 body.isMac.isEnabledBackgroundGradient .mat-drawer-side,
 body.isMac.isEnabledBackgroundGradient .mat-sidenav,
 body.isMac.isEnabledBackgroundGradient .mat-sidenav:focus .mat-drawer-side,
@@ -935,8 +806,7 @@ body.isDarkTheme .mat-menu-item .mat-icon-no-color,
 body.isDarkTheme .mat-menu-item-submenu-trigger::after,
 body.isDarkTheme button,
 body.isDarkTheme.isDisableBackgroundGradient .mat-menu-item .mat-icon-no-color,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-menu-item-submenu-trigger::after,
+body.isDarkTheme.isDisableBackgroundGradient .mat-menu-item-submenu-trigger::after,
 body.isDarkTheme.isDisableBackgroundGradient button,
 body.isDisableBackgroundGradient .mat-menu-item .mat-icon-no-color,
 body.isDisableBackgroundGradient .mat-menu-item-submenu-trigger::after,
@@ -948,8 +818,7 @@ body.isLightTheme .mat-menu-item .mat-icon-no-color,
 body.isLightTheme .mat-menu-item-submenu-trigger::after,
 body.isLightTheme button,
 body.isLightTheme.isDisableBackgroundGradient .mat-menu-item .mat-icon-no-color,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-menu-item-submenu-trigger::after,
+body.isLightTheme.isDisableBackgroundGradient .mat-menu-item-submenu-trigger::after,
 body.isLightTheme.isDisableBackgroundGradient button,
 body.isMac.isEnabledBackgroundGradient .mat-menu-item .mat-icon-no-color,
 body.isMac.isEnabledBackgroundGradient .mat-menu-item-submenu-trigger::after,
@@ -981,16 +850,12 @@ body.isWeb.isEnabledBackgroundGradient .mat-sidenav .mat-icon-no-color {
 }
 
 body .header-wrapper .current-task-title,
-body.isCurrent.isCurrent.isCurrent.isCurrent
-  .header-wrapper
-  .current-task-title,
+body.isCurrent.isCurrent.isCurrent.isCurrent .header-wrapper .current-task-title,
 body.isDarkTheme .header-wrapper .current-task-title,
 body.isDarkTheme.isCurrent.isCurrent.isCurrent.isCurrent
   .header-wrapper
   .current-task-title,
-body.isDarkTheme.isDisableBackgroundGradient
-  .header-wrapper
-  .current-task-title,
+body.isDarkTheme.isDisableBackgroundGradient .header-wrapper .current-task-title,
 body.isDarkTheme.isDisableBackgroundGradient.isCurrent.isCurrent.isCurrent.isCurrent
   .header-wrapper
   .current-task-title,
@@ -1006,9 +871,7 @@ body.isLightTheme .header-wrapper .current-task-title,
 body.isLightTheme.isCurrent.isCurrent.isCurrent.isCurrent
   .header-wrapper
   .current-task-title,
-body.isLightTheme.isDisableBackgroundGradient
-  .header-wrapper
-  .current-task-title,
+body.isLightTheme.isDisableBackgroundGradient .header-wrapper .current-task-title,
 body.isLightTheme.isDisableBackgroundGradient.isCurrent.isCurrent.isCurrent.isCurrent
   .header-wrapper
   .current-task-title,
@@ -1091,8 +954,7 @@ body .title-and-tags-wrapper:focus::after,
 body.isDarkTheme .task-title:focus::after,
 body.isDarkTheme .title-and-tags-wrapper:focus::after,
 body.isDarkTheme.isDisableBackgroundGradient .task-title:focus::after,
-body.isDarkTheme.isDisableBackgroundGradient
-  .title-and-tags-wrapper:focus::after,
+body.isDarkTheme.isDisableBackgroundGradient .title-and-tags-wrapper:focus::after,
 body.isDisableBackgroundGradient .task-title:focus::after,
 body.isDisableBackgroundGradient .title-and-tags-wrapper:focus::after,
 body.isEnabledBackgroundGradient .task-title:focus::after,
@@ -1100,8 +962,7 @@ body.isEnabledBackgroundGradient .title-and-tags-wrapper:focus::after,
 body.isLightTheme .task-title:focus::after,
 body.isLightTheme .title-and-tags-wrapper:focus::after,
 body.isLightTheme.isDisableBackgroundGradient .task-title:focus::after,
-body.isLightTheme.isDisableBackgroundGradient
-  .title-and-tags-wrapper:focus::after,
+body.isLightTheme.isDisableBackgroundGradient .title-and-tags-wrapper:focus::after,
 body.isMac.isEnabledBackgroundGradient .task-title:focus::after,
 body.isMac.isEnabledBackgroundGradient .title-and-tags-wrapper:focus::after,
 body.isWeb.isEnabledBackgroundGradient .task-title:focus::after,
@@ -1148,14 +1009,11 @@ body.isDarkTheme .mat-stroked-button.mat-button-disabled.mat-button-disabled,
 body.isDarkTheme .mat-stroked-button.mat-primary.mat-button-disabled,
 body.isDarkTheme .mat-stroked-button.mat-warn.mat-button-disabled,
 body.isDarkTheme .mat-stroked-button:not(.mat-button-disabled),
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-button.mat-accent.mat-button-disabled,
+body.isDarkTheme.isDisableBackgroundGradient .mat-button.mat-accent.mat-button-disabled,
 body.isDarkTheme.isDisableBackgroundGradient
   .mat-button.mat-button-disabled.mat-button-disabled,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-button.mat-primary.mat-button-disabled,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-button.mat-warn.mat-button-disabled,
+body.isDarkTheme.isDisableBackgroundGradient .mat-button.mat-primary.mat-button-disabled,
+body.isDarkTheme.isDisableBackgroundGradient .mat-button.mat-warn.mat-button-disabled,
 body.isDarkTheme.isDisableBackgroundGradient
   .mat-icon-button.mat-accent.mat-button-disabled,
 body.isDarkTheme.isDisableBackgroundGradient
@@ -1175,46 +1033,32 @@ body.isDarkTheme.isDisableBackgroundGradient
 body.isDarkTheme.isDisableBackgroundGradient
   .mat-stroked-button:not(.mat-button-disabled),
 body.isDisableBackgroundGradient .mat-button.mat-accent.mat-button-disabled,
-body.isDisableBackgroundGradient
-  .mat-button.mat-button-disabled.mat-button-disabled,
+body.isDisableBackgroundGradient .mat-button.mat-button-disabled.mat-button-disabled,
 body.isDisableBackgroundGradient .mat-button.mat-primary.mat-button-disabled,
 body.isDisableBackgroundGradient .mat-button.mat-warn.mat-button-disabled,
-body.isDisableBackgroundGradient
-  .mat-icon-button.mat-accent.mat-button-disabled,
-body.isDisableBackgroundGradient
-  .mat-icon-button.mat-button-disabled.mat-button-disabled,
-body.isDisableBackgroundGradient
-  .mat-icon-button.mat-primary.mat-button-disabled,
+body.isDisableBackgroundGradient .mat-icon-button.mat-accent.mat-button-disabled,
+body.isDisableBackgroundGradient .mat-icon-button.mat-button-disabled.mat-button-disabled,
+body.isDisableBackgroundGradient .mat-icon-button.mat-primary.mat-button-disabled,
 body.isDisableBackgroundGradient .mat-icon-button.mat-warn.mat-button-disabled,
-body.isDisableBackgroundGradient
-  .mat-stroked-button.mat-accent.mat-button-disabled,
+body.isDisableBackgroundGradient .mat-stroked-button.mat-accent.mat-button-disabled,
 body.isDisableBackgroundGradient
   .mat-stroked-button.mat-button-disabled.mat-button-disabled,
-body.isDisableBackgroundGradient
-  .mat-stroked-button.mat-primary.mat-button-disabled,
-body.isDisableBackgroundGradient
-  .mat-stroked-button.mat-warn.mat-button-disabled,
+body.isDisableBackgroundGradient .mat-stroked-button.mat-primary.mat-button-disabled,
+body.isDisableBackgroundGradient .mat-stroked-button.mat-warn.mat-button-disabled,
 body.isDisableBackgroundGradient .mat-stroked-button:not(.mat-button-disabled),
 body.isEnabledBackgroundGradient .mat-button.mat-accent.mat-button-disabled,
-body.isEnabledBackgroundGradient
-  .mat-button.mat-button-disabled.mat-button-disabled,
+body.isEnabledBackgroundGradient .mat-button.mat-button-disabled.mat-button-disabled,
 body.isEnabledBackgroundGradient .mat-button.mat-primary.mat-button-disabled,
 body.isEnabledBackgroundGradient .mat-button.mat-warn.mat-button-disabled,
-body.isEnabledBackgroundGradient
-  .mat-icon-button.mat-accent.mat-button-disabled,
-body.isEnabledBackgroundGradient
-  .mat-icon-button.mat-button-disabled.mat-button-disabled,
-body.isEnabledBackgroundGradient
-  .mat-icon-button.mat-primary.mat-button-disabled,
+body.isEnabledBackgroundGradient .mat-icon-button.mat-accent.mat-button-disabled,
+body.isEnabledBackgroundGradient .mat-icon-button.mat-button-disabled.mat-button-disabled,
+body.isEnabledBackgroundGradient .mat-icon-button.mat-primary.mat-button-disabled,
 body.isEnabledBackgroundGradient .mat-icon-button.mat-warn.mat-button-disabled,
-body.isEnabledBackgroundGradient
-  .mat-stroked-button.mat-accent.mat-button-disabled,
+body.isEnabledBackgroundGradient .mat-stroked-button.mat-accent.mat-button-disabled,
 body.isEnabledBackgroundGradient
   .mat-stroked-button.mat-button-disabled.mat-button-disabled,
-body.isEnabledBackgroundGradient
-  .mat-stroked-button.mat-primary.mat-button-disabled,
-body.isEnabledBackgroundGradient
-  .mat-stroked-button.mat-warn.mat-button-disabled,
+body.isEnabledBackgroundGradient .mat-stroked-button.mat-primary.mat-button-disabled,
+body.isEnabledBackgroundGradient .mat-stroked-button.mat-warn.mat-button-disabled,
 body.isEnabledBackgroundGradient .mat-stroked-button:not(.mat-button-disabled),
 body.isLightTheme .mat-button.mat-accent.mat-button-disabled,
 body.isLightTheme .mat-button.mat-button-disabled.mat-button-disabled,
@@ -1229,14 +1073,11 @@ body.isLightTheme .mat-stroked-button.mat-button-disabled.mat-button-disabled,
 body.isLightTheme .mat-stroked-button.mat-primary.mat-button-disabled,
 body.isLightTheme .mat-stroked-button.mat-warn.mat-button-disabled,
 body.isLightTheme .mat-stroked-button:not(.mat-button-disabled),
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-button.mat-accent.mat-button-disabled,
+body.isLightTheme.isDisableBackgroundGradient .mat-button.mat-accent.mat-button-disabled,
 body.isLightTheme.isDisableBackgroundGradient
   .mat-button.mat-button-disabled.mat-button-disabled,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-button.mat-primary.mat-button-disabled,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-button.mat-warn.mat-button-disabled,
+body.isLightTheme.isDisableBackgroundGradient .mat-button.mat-primary.mat-button-disabled,
+body.isLightTheme.isDisableBackgroundGradient .mat-button.mat-warn.mat-button-disabled,
 body.isLightTheme.isDisableBackgroundGradient
   .mat-icon-button.mat-accent.mat-button-disabled,
 body.isLightTheme.isDisableBackgroundGradient
@@ -1255,56 +1096,40 @@ body.isLightTheme.isDisableBackgroundGradient
   .mat-stroked-button.mat-warn.mat-button-disabled,
 body.isLightTheme.isDisableBackgroundGradient
   .mat-stroked-button:not(.mat-button-disabled),
-body.isMac.isEnabledBackgroundGradient
-  .mat-button.mat-accent.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-button.mat-accent.mat-button-disabled,
 body.isMac.isEnabledBackgroundGradient
   .mat-button.mat-button-disabled.mat-button-disabled,
-body.isMac.isEnabledBackgroundGradient
-  .mat-button.mat-primary.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-button.mat-primary.mat-button-disabled,
 body.isMac.isEnabledBackgroundGradient .mat-button.mat-warn.mat-button-disabled,
-body.isMac.isEnabledBackgroundGradient
-  .mat-icon-button.mat-accent.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-icon-button.mat-accent.mat-button-disabled,
 body.isMac.isEnabledBackgroundGradient
   .mat-icon-button.mat-button-disabled.mat-button-disabled,
-body.isMac.isEnabledBackgroundGradient
-  .mat-icon-button.mat-primary.mat-button-disabled,
-body.isMac.isEnabledBackgroundGradient
-  .mat-icon-button.mat-warn.mat-button-disabled,
-body.isMac.isEnabledBackgroundGradient
-  .mat-stroked-button.mat-accent.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-icon-button.mat-primary.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-icon-button.mat-warn.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-stroked-button.mat-accent.mat-button-disabled,
 body.isMac.isEnabledBackgroundGradient
   .mat-stroked-button.mat-button-disabled.mat-button-disabled,
 body.isMac.isEnabledBackgroundGradient
   .mat-stroked-button.mat-primary.mat-button-disabled,
-body.isMac.isEnabledBackgroundGradient
-  .mat-stroked-button.mat-warn.mat-button-disabled,
-body.isMac.isEnabledBackgroundGradient
-  .mat-stroked-button:not(.mat-button-disabled),
-body.isWeb.isEnabledBackgroundGradient
-  .mat-button.mat-accent.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-stroked-button.mat-warn.mat-button-disabled,
+body.isMac.isEnabledBackgroundGradient .mat-stroked-button:not(.mat-button-disabled),
+body.isWeb.isEnabledBackgroundGradient .mat-button.mat-accent.mat-button-disabled,
 body.isWeb.isEnabledBackgroundGradient
   .mat-button.mat-button-disabled.mat-button-disabled,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-button.mat-primary.mat-button-disabled,
+body.isWeb.isEnabledBackgroundGradient .mat-button.mat-primary.mat-button-disabled,
 body.isWeb.isEnabledBackgroundGradient .mat-button.mat-warn.mat-button-disabled,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-icon-button.mat-accent.mat-button-disabled,
+body.isWeb.isEnabledBackgroundGradient .mat-icon-button.mat-accent.mat-button-disabled,
 body.isWeb.isEnabledBackgroundGradient
   .mat-icon-button.mat-button-disabled.mat-button-disabled,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-icon-button.mat-primary.mat-button-disabled,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-icon-button.mat-warn.mat-button-disabled,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-stroked-button.mat-accent.mat-button-disabled,
+body.isWeb.isEnabledBackgroundGradient .mat-icon-button.mat-primary.mat-button-disabled,
+body.isWeb.isEnabledBackgroundGradient .mat-icon-button.mat-warn.mat-button-disabled,
+body.isWeb.isEnabledBackgroundGradient .mat-stroked-button.mat-accent.mat-button-disabled,
 body.isWeb.isEnabledBackgroundGradient
   .mat-stroked-button.mat-button-disabled.mat-button-disabled,
 body.isWeb.isEnabledBackgroundGradient
   .mat-stroked-button.mat-primary.mat-button-disabled,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-stroked-button.mat-warn.mat-button-disabled,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-stroked-button:not(.mat-button-disabled) {
+body.isWeb.isEnabledBackgroundGradient .mat-stroked-button.mat-warn.mat-button-disabled,
+body.isWeb.isEnabledBackgroundGradient .mat-stroked-button:not(.mat-button-disabled) {
   color: var(--color-foreground) !important;
   border-color: var(--color-large-toggle-panels-inputs) !important;
 }
@@ -1368,9 +1193,7 @@ body.isDarkTheme.isDisableBackgroundGradient
   .mat-dialog-container,
 body.isDarkTheme.isDisableBackgroundGradient .mat-stepper-horizontal,
 body.isDarkTheme.isDisableBackgroundGradient .mat-stepper-vertical,
-body.isDarkTheme.isDisableBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell,
+body.isDarkTheme.isDisableBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell,
 body.isDarkTheme.isDisableBackgroundGradient
   .owl-dt-calendar-table
   .owl-dt-calendar-header,
@@ -1379,9 +1202,7 @@ body.isDarkTheme.isDisableBackgroundGradient
   .owl-dt-control-button-arrow,
 body.isDarkTheme.isDisableBackgroundGradient .owl-dt-schedule-item:focus,
 body.isDarkTheme.isDisableBackgroundGradient .owl-dt-schedule-item:hover,
-body.isDarkTheme.isDisableBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input,
+body.isDarkTheme.isDisableBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input,
 body.isDarkTheme.isDisableBackgroundGradient .owl-dt-timer-divider,
 body.isDisableBackgroundGradient .mat-mdc-dialog-surface,
 body.isDisableBackgroundGradient .mat-dialog-container,
@@ -1433,45 +1254,31 @@ body.isLightTheme.isDisableBackgroundGradient
   .owl-dt-control-button-arrow,
 body.isLightTheme.isDisableBackgroundGradient .owl-dt-schedule-item:focus,
 body.isLightTheme.isDisableBackgroundGradient .owl-dt-schedule-item:hover,
-body.isLightTheme.isDisableBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input,
+body.isLightTheme.isDisableBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input,
 body.isLightTheme.isDisableBackgroundGradient .owl-dt-timer-divider,
 body.isMac.isEnabledBackgroundGradient .mat-dialog-container,
 body.isMac.isEnabledBackgroundGradient .mat-stepper-horizontal,
 body.isMac.isEnabledBackgroundGradient .mat-stepper-vertical,
-body.isMac.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell,
-body.isMac.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-header,
+body.isMac.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell,
+body.isMac.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-header,
 body.isMac.isEnabledBackgroundGradient
   .owl-dt-control-period-button
   .owl-dt-control-button-arrow,
 body.isMac.isEnabledBackgroundGradient .owl-dt-schedule-item:focus,
 body.isMac.isEnabledBackgroundGradient .owl-dt-schedule-item:hover,
-body.isMac.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input,
+body.isMac.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input,
 body.isMac.isEnabledBackgroundGradient .owl-dt-timer-divider,
 body.isWeb.isEnabledBackgroundGradient .mat-dialog-container,
 body.isWeb.isEnabledBackgroundGradient .mat-stepper-horizontal,
 body.isWeb.isEnabledBackgroundGradient .mat-stepper-vertical,
-body.isWeb.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell,
-body.isWeb.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-header,
+body.isWeb.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell,
+body.isWeb.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-header,
 body.isWeb.isEnabledBackgroundGradient
   .owl-dt-control-period-button
   .owl-dt-control-button-arrow,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-schedule-item:focus,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-schedule-item:hover,
-body.isWeb.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input,
+body.isWeb.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-timer-divider {
   background-color: var(--color-background-sidebar) !important;
   color: var(--color-foreground) !important;
@@ -1508,12 +1315,8 @@ body.isDarkTheme .owl-dt-calendar-table .owl-dt-calendar-cell:focus,
 body.isDarkTheme .owl-dt-calendar-table .owl-dt-calendar-cell:hover,
 body.isDarkTheme .owl-dt-calendar-table .owl-dt-calendar-header:focus,
 body.isDarkTheme .owl-dt-calendar-table .owl-dt-calendar-header:hover,
-body.isDarkTheme
-  .owl-dt-control-period-button
-  .owl-dt-control-button-arrow:focus,
-body.isDarkTheme
-  .owl-dt-control-period-button
-  .owl-dt-control-button-arrow:hover,
+body.isDarkTheme .owl-dt-control-period-button .owl-dt-control-button-arrow:focus,
+body.isDarkTheme .owl-dt-control-period-button .owl-dt-control-button-arrow:hover,
 body.isDarkTheme .owl-dt-schedule-item:focus:focus,
 body.isDarkTheme .owl-dt-schedule-item:focus:hover,
 body.isDarkTheme .owl-dt-schedule-item:hover:focus,
@@ -1564,18 +1367,10 @@ body.isDisableBackgroundGradient .mat-stepper-horizontal:focus,
 body.isDisableBackgroundGradient .mat-stepper-horizontal:hover,
 body.isDisableBackgroundGradient .mat-stepper-vertical:focus,
 body.isDisableBackgroundGradient .mat-stepper-vertical:hover,
-body.isDisableBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:focus,
-body.isDisableBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:hover,
-body.isDisableBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-header:focus,
-body.isDisableBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-header:hover,
+body.isDisableBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:focus,
+body.isDisableBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:hover,
+body.isDisableBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-header:focus,
+body.isDisableBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-header:hover,
 body.isDisableBackgroundGradient
   .owl-dt-control-period-button
   .owl-dt-control-button-arrow:focus,
@@ -1586,12 +1381,8 @@ body.isDisableBackgroundGradient .owl-dt-schedule-item:focus:focus,
 body.isDisableBackgroundGradient .owl-dt-schedule-item:focus:hover,
 body.isDisableBackgroundGradient .owl-dt-schedule-item:hover:focus,
 body.isDisableBackgroundGradient .owl-dt-schedule-item:hover:hover,
-body.isDisableBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:focus,
-body.isDisableBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:hover,
+body.isDisableBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:focus,
+body.isDisableBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:hover,
 body.isDisableBackgroundGradient .owl-dt-timer-divider:focus,
 body.isDisableBackgroundGradient .owl-dt-timer-divider:hover,
 body.isEnabledBackgroundGradient .mat-dialog-container:focus,
@@ -1600,18 +1391,10 @@ body.isEnabledBackgroundGradient .mat-stepper-horizontal:focus,
 body.isEnabledBackgroundGradient .mat-stepper-horizontal:hover,
 body.isEnabledBackgroundGradient .mat-stepper-vertical:focus,
 body.isEnabledBackgroundGradient .mat-stepper-vertical:hover,
-body.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:focus,
-body.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:hover,
-body.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-header:focus,
-body.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-header:hover,
+body.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:focus,
+body.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:hover,
+body.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-header:focus,
+body.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-header:hover,
 body.isEnabledBackgroundGradient
   .owl-dt-control-period-button
   .owl-dt-control-button-arrow:focus,
@@ -1622,12 +1405,8 @@ body.isEnabledBackgroundGradient .owl-dt-schedule-item:focus:focus,
 body.isEnabledBackgroundGradient .owl-dt-schedule-item:focus:hover,
 body.isEnabledBackgroundGradient .owl-dt-schedule-item:hover:focus,
 body.isEnabledBackgroundGradient .owl-dt-schedule-item:hover:hover,
-body.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:focus,
-body.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:hover,
+body.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:focus,
+body.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:hover,
 body.isEnabledBackgroundGradient .owl-dt-timer-divider:focus,
 body.isEnabledBackgroundGradient .owl-dt-timer-divider:hover,
 body.isLightTheme .mat-dialog-container:focus,
@@ -1640,12 +1419,8 @@ body.isLightTheme .owl-dt-calendar-table .owl-dt-calendar-cell:focus,
 body.isLightTheme .owl-dt-calendar-table .owl-dt-calendar-cell:hover,
 body.isLightTheme .owl-dt-calendar-table .owl-dt-calendar-header:focus,
 body.isLightTheme .owl-dt-calendar-table .owl-dt-calendar-header:hover,
-body.isLightTheme
-  .owl-dt-control-period-button
-  .owl-dt-control-button-arrow:focus,
-body.isLightTheme
-  .owl-dt-control-period-button
-  .owl-dt-control-button-arrow:hover,
+body.isLightTheme .owl-dt-control-period-button .owl-dt-control-button-arrow:focus,
+body.isLightTheme .owl-dt-control-period-button .owl-dt-control-button-arrow:hover,
 body.isLightTheme .owl-dt-schedule-item:focus:focus,
 body.isLightTheme .owl-dt-schedule-item:focus:hover,
 body.isLightTheme .owl-dt-schedule-item:hover:focus,
@@ -1696,12 +1471,8 @@ body.isMac.isEnabledBackgroundGradient .mat-stepper-horizontal:focus,
 body.isMac.isEnabledBackgroundGradient .mat-stepper-horizontal:hover,
 body.isMac.isEnabledBackgroundGradient .mat-stepper-vertical:focus,
 body.isMac.isEnabledBackgroundGradient .mat-stepper-vertical:hover,
-body.isMac.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:focus,
-body.isMac.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:hover,
+body.isMac.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:focus,
+body.isMac.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:hover,
 body.isMac.isEnabledBackgroundGradient
   .owl-dt-calendar-table
   .owl-dt-calendar-header:focus,
@@ -1718,12 +1489,8 @@ body.isMac.isEnabledBackgroundGradient .owl-dt-schedule-item:focus:focus,
 body.isMac.isEnabledBackgroundGradient .owl-dt-schedule-item:focus:hover,
 body.isMac.isEnabledBackgroundGradient .owl-dt-schedule-item:hover:focus,
 body.isMac.isEnabledBackgroundGradient .owl-dt-schedule-item:hover:hover,
-body.isMac.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:focus,
-body.isMac.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:hover,
+body.isMac.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:focus,
+body.isMac.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:hover,
 body.isMac.isEnabledBackgroundGradient .owl-dt-timer-divider:focus,
 body.isMac.isEnabledBackgroundGradient .owl-dt-timer-divider:hover,
 body.isWeb.isEnabledBackgroundGradient .mat-dialog-container:focus,
@@ -1732,12 +1499,8 @@ body.isWeb.isEnabledBackgroundGradient .mat-stepper-horizontal:focus,
 body.isWeb.isEnabledBackgroundGradient .mat-stepper-horizontal:hover,
 body.isWeb.isEnabledBackgroundGradient .mat-stepper-vertical:focus,
 body.isWeb.isEnabledBackgroundGradient .mat-stepper-vertical:hover,
-body.isWeb.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:focus,
-body.isWeb.isEnabledBackgroundGradient
-  .owl-dt-calendar-table
-  .owl-dt-calendar-cell:hover,
+body.isWeb.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:focus,
+body.isWeb.isEnabledBackgroundGradient .owl-dt-calendar-table .owl-dt-calendar-cell:hover,
 body.isWeb.isEnabledBackgroundGradient
   .owl-dt-calendar-table
   .owl-dt-calendar-header:focus,
@@ -1754,12 +1517,8 @@ body.isWeb.isEnabledBackgroundGradient .owl-dt-schedule-item:focus:focus,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-schedule-item:focus:hover,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-schedule-item:hover:focus,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-schedule-item:hover:hover,
-body.isWeb.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:focus,
-body.isWeb.isEnabledBackgroundGradient
-  .owl-dt-timer-content
-  .owl-dt-timer-input:hover,
+body.isWeb.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:focus,
+body.isWeb.isEnabledBackgroundGradient .owl-dt-timer-content .owl-dt-timer-input:hover,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-timer-divider:focus,
 body.isWeb.isEnabledBackgroundGradient .owl-dt-timer-divider:hover {
   color: var(--color-accent) !important;
@@ -1902,10 +1661,7 @@ body.isDarkTheme .mat-drawer-container .isSelected .box,
 body.isDarkTheme .side,
 body.isDarkTheme .textarea,
 body.isDarkTheme.isDisableBackgroundGradient .isOpen .side,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .box,
+body.isDarkTheme.isDisableBackgroundGradient .mat-drawer-container .isSelected .box,
 body.isDarkTheme.isDisableBackgroundGradient .side,
 body.isDarkTheme.isDisableBackgroundGradient .textarea,
 body.isDisableBackgroundGradient .isOpen .side,
@@ -1923,10 +1679,7 @@ body.isLightTheme .mat-drawer-container .isSelected .box,
 body.isLightTheme .side,
 body.isLightTheme .textarea,
 body.isLightTheme.isDisableBackgroundGradient .isOpen .side,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .box,
+body.isLightTheme.isDisableBackgroundGradient .mat-drawer-container .isSelected .box,
 body.isLightTheme.isDisableBackgroundGradient .side,
 body.isLightTheme.isDisableBackgroundGradient .textarea,
 body.isMac.isEnabledBackgroundGradient .isOpen .side,
@@ -1946,19 +1699,15 @@ body .markdown-wrapper,
 body .mat-expansion-panel-header:not(.mat-expanded):focus,
 body.isDarkTheme .markdown-wrapper,
 body.isDarkTheme .mat-expansion-panel-header:not(.mat-expanded):focus,
-body.isDarkTheme
-  mat-expansion-panel
-  .mat-expansion-panel-header:not(.mat-expanded):hover,
+body.isDarkTheme mat-expansion-panel .mat-expansion-panel-header:not(.mat-expanded):hover,
 body.isDarkTheme.isDisableBackgroundGradient .markdown-wrapper,
 body.isDarkTheme.isDisableBackgroundGradient
   .mat-expansion-panel-header:not(.mat-expanded):focus,
 body.isDisableBackgroundGradient .markdown-wrapper,
-body.isDisableBackgroundGradient
-  .mat-expansion-panel-header:not(.mat-expanded):focus,
+body.isDisableBackgroundGradient .mat-expansion-panel-header:not(.mat-expanded):focus,
 .mat-expansion-panel-header:not(.mat-expanded):hover,
 body.isEnabledBackgroundGradient .markdown-wrapper,
-body.isEnabledBackgroundGradient
-  .mat-expansion-panel-header:not(.mat-expanded):focus,
+body.isEnabledBackgroundGradient .mat-expansion-panel-header:not(.mat-expanded):focus,
 body.isEnabledBackgroundGradient
   mat-expansion-panel
   .mat-expansion-panel-header:not(.mat-expanded):hover,
@@ -2058,18 +1807,10 @@ body.isDarkTheme.isDisableBackgroundGradient
   .page-settings
   .config-section
   .collapsible-header,
-body.isDarkTheme.isDisableBackgroundGradient
-  section.config-section
-  .collapsible-header,
-body.isDisableBackgroundGradient
-  .page-settings
-  .config-section
-  .collapsible-header,
+body.isDarkTheme.isDisableBackgroundGradient section.config-section .collapsible-header,
+body.isDisableBackgroundGradient .page-settings .config-section .collapsible-header,
 body.isDisableBackgroundGradient section.config-section .collapsible-header,
-body.isEnabledBackgroundGradient
-  .page-settings
-  .config-section
-  .collapsible-header,
+body.isEnabledBackgroundGradient .page-settings .config-section .collapsible-header,
 body.isEnabledBackgroundGradient section.config-section .collapsible-header,
 body.isLightTheme .page-settings .config-section .collapsible-header,
 body.isLightTheme section.config-section .collapsible-header,
@@ -2077,23 +1818,11 @@ body.isLightTheme.isDisableBackgroundGradient
   .page-settings
   .config-section
   .collapsible-header,
-body.isLightTheme.isDisableBackgroundGradient
-  section.config-section
-  .collapsible-header,
-body.isMac.isEnabledBackgroundGradient
-  .page-settings
-  .config-section
-  .collapsible-header,
-body.isMac.isEnabledBackgroundGradient
-  section.config-section
-  .collapsible-header,
-body.isWeb.isEnabledBackgroundGradient
-  .page-settings
-  .config-section
-  .collapsible-header,
-body.isWeb.isEnabledBackgroundGradient
-  section.config-section
-  .collapsible-header {
+body.isLightTheme.isDisableBackgroundGradient section.config-section .collapsible-header,
+body.isMac.isEnabledBackgroundGradient .page-settings .config-section .collapsible-header,
+body.isMac.isEnabledBackgroundGradient section.config-section .collapsible-header,
+body.isWeb.isEnabledBackgroundGradient .page-settings .config-section .collapsible-header,
+body.isWeb.isEnabledBackgroundGradient section.config-section .collapsible-header {
   border-color: var(--color-border-panels) !important;
 }
 body .created,
@@ -2109,9 +1838,7 @@ body.isDarkTheme .mat-select-value,
 body.isDarkTheme .time,
 body.isDarkTheme .time-wrapper,
 body.isDarkTheme.isDisableBackgroundGradient .created,
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-form-field-appearance-legacy
-  .mat-hint,
+body.isDarkTheme.isDisableBackgroundGradient .mat-form-field-appearance-legacy .mat-hint,
 body.isDarkTheme.isDisableBackgroundGradient .mat-hint,
 body.isDarkTheme.isDisableBackgroundGradient .mat-select-value,
 body.isDarkTheme.isDisableBackgroundGradient .time,
@@ -2135,25 +1862,19 @@ body.isLightTheme .mat-select-value,
 body.isLightTheme .time,
 body.isLightTheme .time-wrapper,
 body.isLightTheme.isDisableBackgroundGradient .created,
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-form-field-appearance-legacy
-  .mat-hint,
+body.isLightTheme.isDisableBackgroundGradient .mat-form-field-appearance-legacy .mat-hint,
 body.isLightTheme.isDisableBackgroundGradient .mat-hint,
 body.isLightTheme.isDisableBackgroundGradient .mat-select-value,
 body.isLightTheme.isDisableBackgroundGradient .time,
 body.isLightTheme.isDisableBackgroundGradient .time-wrapper,
 body.isMac.isEnabledBackgroundGradient .created,
-body.isMac.isEnabledBackgroundGradient
-  .mat-form-field-appearance-legacy
-  .mat-hint,
+body.isMac.isEnabledBackgroundGradient .mat-form-field-appearance-legacy .mat-hint,
 body.isMac.isEnabledBackgroundGradient .mat-hint,
 body.isMac.isEnabledBackgroundGradient .mat-select-value,
 body.isMac.isEnabledBackgroundGradient .time,
 body.isMac.isEnabledBackgroundGradient .time-wrapper,
 body.isWeb.isEnabledBackgroundGradient .created,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-form-field-appearance-legacy
-  .mat-hint,
+body.isWeb.isEnabledBackgroundGradient .mat-form-field-appearance-legacy .mat-hint,
 body.isWeb.isEnabledBackgroundGradient .mat-hint,
 body.isWeb.isEnabledBackgroundGradient .mat-select-value,
 body.isWeb.isEnabledBackgroundGradient .time,
@@ -2165,12 +1886,8 @@ body.isDarkTheme .mat-form-field-appearance-legacy .mat-form-field-label,
 body.isDarkTheme.isDisableBackgroundGradient
   .mat-form-field-appearance-legacy
   .mat-form-field-label,
-body.isDisableBackgroundGradient
-  .mat-form-field-appearance-legacy
-  .mat-form-field-label,
-body.isEnabledBackgroundGradient
-  .mat-form-field-appearance-legacy
-  .mat-form-field-label,
+body.isDisableBackgroundGradient .mat-form-field-appearance-legacy .mat-form-field-label,
+body.isEnabledBackgroundGradient .mat-form-field-appearance-legacy .mat-form-field-label,
 body.isLightTheme .mat-form-field-appearance-legacy .mat-form-field-label,
 body.isLightTheme.isDisableBackgroundGradient
   .mat-form-field-appearance-legacy
@@ -2252,35 +1969,25 @@ body.isDarkTheme .add-task-form input::-moz-placeholder,
 body.isDarkTheme .add-task-form.isElevated input::-moz-placeholder,
 body.isDarkTheme .info-bar input::-moz-placeholder,
 body.isDarkTheme .info-bar.isElevated input::-moz-placeholder,
-body.isDarkTheme.isDisableBackgroundGradient
-  .add-task-form
-  input::-moz-placeholder,
+body.isDarkTheme.isDisableBackgroundGradient .add-task-form input::-moz-placeholder,
 body.isDarkTheme.isDisableBackgroundGradient
   .add-task-form.isElevated
   input::-moz-placeholder,
 body.isDarkTheme.isDisableBackgroundGradient .info-bar input::-moz-placeholder,
-body.isDarkTheme.isDisableBackgroundGradient
-  .info-bar.isElevated
-  input::-moz-placeholder,
+body.isDarkTheme.isDisableBackgroundGradient .info-bar.isElevated input::-moz-placeholder,
 body.isDisableBackgroundGradient .add-task-form input::-moz-placeholder,
-body.isDisableBackgroundGradient
-  .add-task-form.isElevated
-  input::-moz-placeholder,
+body.isDisableBackgroundGradient .add-task-form.isElevated input::-moz-placeholder,
 body.isDisableBackgroundGradient .info-bar input::-moz-placeholder,
 body.isDisableBackgroundGradient .info-bar.isElevated input::-moz-placeholder,
 body.isEnabledBackgroundGradient .add-task-form input::-moz-placeholder,
-body.isEnabledBackgroundGradient
-  .add-task-form.isElevated
-  input::-moz-placeholder,
+body.isEnabledBackgroundGradient .add-task-form.isElevated input::-moz-placeholder,
 body.isEnabledBackgroundGradient .info-bar input::-moz-placeholder,
 body.isEnabledBackgroundGradient .info-bar.isElevated input::-moz-placeholder,
 body.isLightTheme .add-task-form input::-moz-placeholder,
 body.isLightTheme .add-task-form.isElevated input::-moz-placeholder,
 body.isLightTheme .info-bar input::-moz-placeholder,
 body.isLightTheme .info-bar.isElevated input::-moz-placeholder,
-body.isLightTheme.isDisableBackgroundGradient
-  .add-task-form
-  input::-moz-placeholder,
+body.isLightTheme.isDisableBackgroundGradient .add-task-form input::-moz-placeholder,
 body.isLightTheme.isDisableBackgroundGradient
   .add-task-form.isElevated
   input::-moz-placeholder,
@@ -2289,21 +1996,13 @@ body.isLightTheme.isDisableBackgroundGradient
   .info-bar.isElevated
   input::-moz-placeholder,
 body.isMac.isEnabledBackgroundGradient .add-task-form input::-moz-placeholder,
-body.isMac.isEnabledBackgroundGradient
-  .add-task-form.isElevated
-  input::-moz-placeholder,
+body.isMac.isEnabledBackgroundGradient .add-task-form.isElevated input::-moz-placeholder,
 body.isMac.isEnabledBackgroundGradient .info-bar input::-moz-placeholder,
-body.isMac.isEnabledBackgroundGradient
-  .info-bar.isElevated
-  input::-moz-placeholder,
+body.isMac.isEnabledBackgroundGradient .info-bar.isElevated input::-moz-placeholder,
 body.isWeb.isEnabledBackgroundGradient .add-task-form input::-moz-placeholder,
-body.isWeb.isEnabledBackgroundGradient
-  .add-task-form.isElevated
-  input::-moz-placeholder,
+body.isWeb.isEnabledBackgroundGradient .add-task-form.isElevated input::-moz-placeholder,
 body.isWeb.isEnabledBackgroundGradient .info-bar input::-moz-placeholder,
-body.isWeb.isEnabledBackgroundGradient
-  .info-bar.isElevated
-  input::-moz-placeholder {
+body.isWeb.isEnabledBackgroundGradient .info-bar.isElevated input::-moz-placeholder {
   color: var(--color-foreground) !important;
 }
 body .add-task-form input:-ms-input-placeholder,
@@ -2314,70 +2013,46 @@ body.isDarkTheme .add-task-form input:-ms-input-placeholder,
 body.isDarkTheme .add-task-form.isElevated input:-ms-input-placeholder,
 body.isDarkTheme .info-bar input:-ms-input-placeholder,
 body.isDarkTheme .info-bar.isElevated input:-ms-input-placeholder,
-body.isDarkTheme.isDisableBackgroundGradient
-  .add-task-form
-  input:-ms-input-placeholder,
+body.isDarkTheme.isDisableBackgroundGradient .add-task-form input:-ms-input-placeholder,
 body.isDarkTheme.isDisableBackgroundGradient
   .add-task-form.isElevated
   input:-ms-input-placeholder,
-body.isDarkTheme.isDisableBackgroundGradient
-  .info-bar
-  input:-ms-input-placeholder,
+body.isDarkTheme.isDisableBackgroundGradient .info-bar input:-ms-input-placeholder,
 body.isDarkTheme.isDisableBackgroundGradient
   .info-bar.isElevated
   input:-ms-input-placeholder,
 body.isDisableBackgroundGradient .add-task-form input:-ms-input-placeholder,
-body.isDisableBackgroundGradient
-  .add-task-form.isElevated
-  input:-ms-input-placeholder,
+body.isDisableBackgroundGradient .add-task-form.isElevated input:-ms-input-placeholder,
 body.isDisableBackgroundGradient .info-bar input:-ms-input-placeholder,
-body.isDisableBackgroundGradient
-  .info-bar.isElevated
-  input:-ms-input-placeholder,
+body.isDisableBackgroundGradient .info-bar.isElevated input:-ms-input-placeholder,
 body.isEnabledBackgroundGradient .add-task-form input:-ms-input-placeholder,
-body.isEnabledBackgroundGradient
-  .add-task-form.isElevated
-  input:-ms-input-placeholder,
+body.isEnabledBackgroundGradient .add-task-form.isElevated input:-ms-input-placeholder,
 body.isEnabledBackgroundGradient .info-bar input:-ms-input-placeholder,
-body.isEnabledBackgroundGradient
-  .info-bar.isElevated
-  input:-ms-input-placeholder,
+body.isEnabledBackgroundGradient .info-bar.isElevated input:-ms-input-placeholder,
 body.isLightTheme .add-task-form input:-ms-input-placeholder,
 body.isLightTheme .add-task-form.isElevated input:-ms-input-placeholder,
 body.isLightTheme .info-bar input:-ms-input-placeholder,
 body.isLightTheme .info-bar.isElevated input:-ms-input-placeholder,
-body.isLightTheme.isDisableBackgroundGradient
-  .add-task-form
-  input:-ms-input-placeholder,
+body.isLightTheme.isDisableBackgroundGradient .add-task-form input:-ms-input-placeholder,
 body.isLightTheme.isDisableBackgroundGradient
   .add-task-form.isElevated
   input:-ms-input-placeholder,
-body.isLightTheme.isDisableBackgroundGradient
-  .info-bar
-  input:-ms-input-placeholder,
+body.isLightTheme.isDisableBackgroundGradient .info-bar input:-ms-input-placeholder,
 body.isLightTheme.isDisableBackgroundGradient
   .info-bar.isElevated
   input:-ms-input-placeholder,
-body.isMac.isEnabledBackgroundGradient
-  .add-task-form
-  input:-ms-input-placeholder,
+body.isMac.isEnabledBackgroundGradient .add-task-form input:-ms-input-placeholder,
 body.isMac.isEnabledBackgroundGradient
   .add-task-form.isElevated
   input:-ms-input-placeholder,
 body.isMac.isEnabledBackgroundGradient .info-bar input:-ms-input-placeholder,
-body.isMac.isEnabledBackgroundGradient
-  .info-bar.isElevated
-  input:-ms-input-placeholder,
-body.isWeb.isEnabledBackgroundGradient
-  .add-task-form
-  input:-ms-input-placeholder,
+body.isMac.isEnabledBackgroundGradient .info-bar.isElevated input:-ms-input-placeholder,
+body.isWeb.isEnabledBackgroundGradient .add-task-form input:-ms-input-placeholder,
 body.isWeb.isEnabledBackgroundGradient
   .add-task-form.isElevated
   input:-ms-input-placeholder,
 body.isWeb.isEnabledBackgroundGradient .info-bar input:-ms-input-placeholder,
-body.isWeb.isEnabledBackgroundGradient
-  .info-bar.isElevated
-  input:-ms-input-placeholder {
+body.isWeb.isEnabledBackgroundGradient .info-bar.isElevated input:-ms-input-placeholder {
   color: var(--color-foreground) !important;
 }
 body .add-task-form input::placeholder,
@@ -2389,13 +2064,9 @@ body.isDarkTheme .add-task-form.isElevated input::placeholder,
 body.isDarkTheme .info-bar input::placeholder,
 body.isDarkTheme .info-bar.isElevated input::placeholder,
 body.isDarkTheme.isDisableBackgroundGradient .add-task-form input::placeholder,
-body.isDarkTheme.isDisableBackgroundGradient
-  .add-task-form.isElevated
-  input::placeholder,
+body.isDarkTheme.isDisableBackgroundGradient .add-task-form.isElevated input::placeholder,
 body.isDarkTheme.isDisableBackgroundGradient .info-bar input::placeholder,
-body.isDarkTheme.isDisableBackgroundGradient
-  .info-bar.isElevated
-  input::placeholder,
+body.isDarkTheme.isDisableBackgroundGradient .info-bar.isElevated input::placeholder,
 body.isDisableBackgroundGradient .add-task-form input::placeholder,
 body.isDisableBackgroundGradient .add-task-form.isElevated input::placeholder,
 body.isDisableBackgroundGradient .info-bar input::placeholder,
@@ -2413,19 +2084,13 @@ body.isLightTheme.isDisableBackgroundGradient
   .add-task-form.isElevated
   input::placeholder,
 body.isLightTheme.isDisableBackgroundGradient .info-bar input::placeholder,
-body.isLightTheme.isDisableBackgroundGradient
-  .info-bar.isElevated
-  input::placeholder,
+body.isLightTheme.isDisableBackgroundGradient .info-bar.isElevated input::placeholder,
 body.isMac.isEnabledBackgroundGradient .add-task-form input::placeholder,
-body.isMac.isEnabledBackgroundGradient
-  .add-task-form.isElevated
-  input::placeholder,
+body.isMac.isEnabledBackgroundGradient .add-task-form.isElevated input::placeholder,
 body.isMac.isEnabledBackgroundGradient .info-bar input::placeholder,
 body.isMac.isEnabledBackgroundGradient .info-bar.isElevated input::placeholder,
 body.isWeb.isEnabledBackgroundGradient .add-task-form input::placeholder,
-body.isWeb.isEnabledBackgroundGradient
-  .add-task-form.isElevated
-  input::placeholder,
+body.isWeb.isEnabledBackgroundGradient .add-task-form.isElevated input::placeholder,
 body.isWeb.isEnabledBackgroundGradient .info-bar input::placeholder,
 body.isWeb.isEnabledBackgroundGradient .info-bar.isElevated input::placeholder {
   color: var(--color-foreground) !important;
@@ -2553,9 +2218,7 @@ body.isLightTheme .mat-slide-toggle-bar,
 body.isLightTheme.isDisableBackgroundGradient .mat-slide-toggle-bar,
 body.isMac.isEnabledBackgroundGradient .mat-slide-toggle-bar,
 body.isWeb.isEnabledBackgroundGradient .mat-slide-toggle-bar {
-  background-color: var(
-    --color-background-slide-toggle-bar-disabled
-  ) !important;
+  background-color: var(--color-background-slide-toggle-bar-disabled) !important;
 }
 /*HACK: .input-item deleted because of button issues*/
 body .mat-expansion-panel-header:not(.mat-expanded),
@@ -2567,10 +2230,8 @@ body.isEnabledBackgroundGradient .mat-expansion-panel-header:not(.mat-expanded),
 body.isLightTheme .mat-expansion-panel-header:not(.mat-expanded),
 body.isLightTheme.isDisableBackgroundGradient
   .mat-expansion-panel-header:not(.mat-expanded),
-body.isMac.isEnabledBackgroundGradient
-  .mat-expansion-panel-header:not(.mat-expanded),
-body.isWeb.isEnabledBackgroundGradient
-  .mat-expansion-panel-header:not(.mat-expanded) {
+body.isMac.isEnabledBackgroundGradient .mat-expansion-panel-header:not(.mat-expanded),
+body.isWeb.isEnabledBackgroundGradient .mat-expansion-panel-header:not(.mat-expanded) {
   background-color: var(--color-background-banner) !important;
 }
 body .mat-tab-label-content,
@@ -2620,44 +2281,18 @@ body.isDisableBackgroundGradient
   > tbody
   > tr.week-row.isExpanded
   > td,
-body.isDisableBackgroundGradient
-  .week
-  table.week-table
-  > tbody
-  > tr.week-row:hover
-  > td,
-body.isDisableBackgroundGradient
-  .week
-  table.week-table
-  > tr.week-row.isExpanded
-  > td,
-body.isDisableBackgroundGradient
-  .week
-  table.week-table
-  > tr.week-row:hover
-  > td,
+body.isDisableBackgroundGradient .week table.week-table > tbody > tr.week-row:hover > td,
+body.isDisableBackgroundGradient .week table.week-table > tr.week-row.isExpanded > td,
+body.isDisableBackgroundGradient .week table.week-table > tr.week-row:hover > td,
 body.isEnabledBackgroundGradient
   .week
   table.week-table
   > tbody
   > tr.week-row.isExpanded
   > td,
-body.isEnabledBackgroundGradient
-  .week
-  table.week-table
-  > tbody
-  > tr.week-row:hover
-  > td,
-body.isEnabledBackgroundGradient
-  .week
-  table.week-table
-  > tr.week-row.isExpanded
-  > td,
-body.isEnabledBackgroundGradient
-  .week
-  table.week-table
-  > tr.week-row:hover
-  > td,
+body.isEnabledBackgroundGradient .week table.week-table > tbody > tr.week-row:hover > td,
+body.isEnabledBackgroundGradient .week table.week-table > tr.week-row.isExpanded > td,
+body.isEnabledBackgroundGradient .week table.week-table > tr.week-row:hover > td,
 body.isLightTheme .week table.week-table > tbody > tr.week-row.isExpanded > td,
 body.isLightTheme .week table.week-table > tbody > tr.week-row:hover > td,
 body.isLightTheme .week table.week-table > tr.week-row.isExpanded > td,
@@ -2701,11 +2336,7 @@ body.isMac.isEnabledBackgroundGradient
   table.week-table
   > tr.week-row.isExpanded
   > td,
-body.isMac.isEnabledBackgroundGradient
-  .week
-  table.week-table
-  > tr.week-row:hover
-  > td,
+body.isMac.isEnabledBackgroundGradient .week table.week-table > tr.week-row:hover > td,
 body.isWeb.isEnabledBackgroundGradient
   .week
   table.week-table
@@ -2723,11 +2354,7 @@ body.isWeb.isEnabledBackgroundGradient
   table.week-table
   > tr.week-row.isExpanded
   > td,
-body.isWeb.isEnabledBackgroundGradient
-  .week
-  table.week-table
-  > tr.week-row:hover
-  > td {
+body.isWeb.isEnabledBackgroundGradient .week table.week-table > tr.week-row:hover > td {
   background-color: var(--color-inputs-focused) !important;
 }
 body .month,
@@ -2952,9 +2579,7 @@ body.isWeb.isEnabledBackgroundGradient table.material-table tr {
 /*NOTE: Custom CSS improvements*/
 body .first-line:hover .hover-controls::before,
 body.isDarkTheme .first-line:hover .hover-controls::before,
-body.isDarkTheme.isDisableBackgroundGradient
-  .first-line:hover
-  .hover-controls::before,
+body.isDarkTheme.isDisableBackgroundGradient .first-line:hover .hover-controls::before,
 body.isDarkTheme.isDisableBackgroundGradient::before,
 body.isDarkTheme::before,
 body.isDisableBackgroundGradient .first-line:hover .hover-controls::before,
@@ -2962,18 +2587,12 @@ body.isDisableBackgroundGradient::before,
 body.isEnabledBackgroundGradient .first-line:hover .hover-controls::before,
 body.isEnabledBackgroundGradient::before,
 body.isLightTheme .first-line:hover .hover-controls::before,
-body.isLightTheme.isDisableBackgroundGradient
-  .first-line:hover
-  .hover-controls::before,
+body.isLightTheme.isDisableBackgroundGradient .first-line:hover .hover-controls::before,
 body.isLightTheme.isDisableBackgroundGradient::before,
 body.isLightTheme::before,
-body.isMac.isEnabledBackgroundGradient
-  .first-line:hover
-  .hover-controls::before,
+body.isMac.isEnabledBackgroundGradient .first-line:hover .hover-controls::before,
 body.isMac.isEnabledBackgroundGradient::before,
-body.isWeb.isEnabledBackgroundGradient
-  .first-line:hover
-  .hover-controls::before,
+body.isWeb.isEnabledBackgroundGradient .first-line:hover .hover-controls::before,
 body.isWeb.isEnabledBackgroundGradient::before,
 body::before {
   display: none;
@@ -2997,16 +2616,10 @@ body.isDarkTheme.isDisableBackgroundGradient
   .isSelected
   .task-handle,
 body.isDisableBackgroundGradient .mat-drawer-container .isSelected .handle-par,
-body.isDisableBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .hover-controls,
+body.isDisableBackgroundGradient .mat-drawer-container .isSelected .hover-controls,
 body.isDisableBackgroundGradient .mat-drawer-container .isSelected .task-handle,
 body.isEnabledBackgroundGradient .mat-drawer-container .isSelected .handle-par,
-body.isEnabledBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .hover-controls,
+body.isEnabledBackgroundGradient .mat-drawer-container .isSelected .hover-controls,
 body.isEnabledBackgroundGradient .mat-drawer-container .isSelected .task-handle,
 body.isLightTheme .mat-drawer-container .isSelected .handle-par,
 body.isLightTheme .mat-drawer-container .isSelected .hover-controls,
@@ -3023,30 +2636,12 @@ body.isLightTheme.isDisableBackgroundGradient
   .mat-drawer-container
   .isSelected
   .task-handle,
-body.isMac.isEnabledBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .handle-par,
-body.isMac.isEnabledBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .hover-controls,
-body.isMac.isEnabledBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .task-handle,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .handle-par,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .hover-controls,
-body.isWeb.isEnabledBackgroundGradient
-  .mat-drawer-container
-  .isSelected
-  .task-handle {
+body.isMac.isEnabledBackgroundGradient .mat-drawer-container .isSelected .handle-par,
+body.isMac.isEnabledBackgroundGradient .mat-drawer-container .isSelected .hover-controls,
+body.isMac.isEnabledBackgroundGradient .mat-drawer-container .isSelected .task-handle,
+body.isWeb.isEnabledBackgroundGradient .mat-drawer-container .isSelected .handle-par,
+body.isWeb.isEnabledBackgroundGradient .mat-drawer-container .isSelected .hover-controls,
+body.isWeb.isEnabledBackgroundGradient .mat-drawer-container .isSelected .task-handle {
   background-color: var(--color-large-toggle-panels) !important;
 }
 body .mat-dialog-container .mat-dialog-content .content,
@@ -3055,23 +2650,14 @@ body.isDarkTheme.isDisableBackgroundGradient
   .mat-dialog-container
   .mat-dialog-content
   .content,
-body.isDisableBackgroundGradient
-  .mat-dialog-container
-  .mat-dialog-content
-  .content,
-body.isEnabledBackgroundGradient
-  .mat-dialog-container
-  .mat-dialog-content
-  .content,
+body.isDisableBackgroundGradient .mat-dialog-container .mat-dialog-content .content,
+body.isEnabledBackgroundGradient .mat-dialog-container .mat-dialog-content .content,
 body.isLightTheme .mat-dialog-container .mat-dialog-content .content,
 body.isLightTheme.isDisableBackgroundGradient
   .mat-dialog-container
   .mat-dialog-content
   .content,
-body.isMac.isEnabledBackgroundGradient
-  .mat-dialog-container
-  .mat-dialog-content
-  .content,
+body.isMac.isEnabledBackgroundGradient .mat-dialog-container .mat-dialog-content .content,
 body.isWeb.isEnabledBackgroundGradient
   .mat-dialog-container
   .mat-dialog-content
@@ -3215,10 +2801,8 @@ body .mdc-text-field--filled:not(.mdc-text-field--disabled),
 body.isDarkTheme .mdc-text-field--filled:not(.mdc-text-field--disabled),
 body.isDarkTheme.isDisableBackgroundGradient
   .mdc-text-field--filled:not(.mdc-text-field--disabled),
-body.isDisableBackgroundGradient
-  .mdc-text-field--filled:not(.mdc-text-field--disabled),
-body.isEnabledBackgroundGradient
-  .mdc-text-field--filled:not(.mdc-text-field--disabled),
+body.isDisableBackgroundGradient .mdc-text-field--filled:not(.mdc-text-field--disabled),
+body.isEnabledBackgroundGradient .mdc-text-field--filled:not(.mdc-text-field--disabled),
 body.isLightTheme .mdc-text-field--filled:not(.mdc-text-field--disabled),
 body.isLightTheme.isDisableBackgroundGradient
   .mdc-text-field--filled:not(.mdc-text-field--disabled),
@@ -3240,47 +2824,6 @@ body.isLightTheme.isDisableBackgroundGradient .mat-mdc-select-panel,
 body.isMac.isEnabledBackgroundGradient .mat-mdc-select-panel,
 body.isWeb.isEnabledBackgroundGradient .mat-mdc-select-panel {
   background-color: var(--color-background-color-options);
-}
-/*Stopwatch colors*/
-body .pulse-circle,
-body.isDarkTheme .pulse-circle,
-body.isDarkTheme.isDisableBackgroundGradient .pulse-circle,
-body.isDisableBackgroundGradient .pulse-circle,
-body.isEnabledBackgroundGradient .pulse-circle,
-body.isLightTheme .pulse-circle,
-body.isLightTheme.isDisableBackgroundGradient .pulse-circle,
-body.isMac.isEnabledBackgroundGradient .pulse-circle,
-body.isWeb.isEnabledBackgroundGradient .pulse-circle {
-  background: var(--color-background-button-shadow) !important;
-}
-body .mat-mdc-mini-fab,
-body.isDarkTheme .mat-mdc-mini-fab,
-body.isDarkTheme.isDisableBackgroundGradient .mat-mdc-mini-fab,
-body.isDisableBackgroundGradient .mat-mdc-mini-fab,
-body.isEnabledBackgroundGradient .mat-mdc-mini-fab,
-body.isLightTheme .mat-mdc-mini-fab,
-body.isLightTheme.isDisableBackgroundGradient .mat-mdc-mini-fab,
-body.isMac.isEnabledBackgroundGradient .mat-mdc-mini-fab,
-body.isWeb.isEnabledBackgroundGradient .mat-mdc-mini-fab {
-  background-color: var(--color-accent);
-}
-/*notes and provider buttons transparent normal, active same with sidebar*/
-body .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isDarkTheme .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isDarkTheme.isDisableBackgroundGradient
-  .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isDisableBackgroundGradient
-  .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isEnabledBackgroundGradient
-  .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isLightTheme .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isLightTheme.isDisableBackgroundGradient
-  .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isMac.isEnabledBackgroundGradient
-  .toggle-notes-btn.isActive.isRouteWithRightPanel::after,
-body.isWeb.isEnabledBackgroundGradient
-  .toggle-notes-btn.isActive.isRouteWithRightPanel::after {
-  background: var(--color-background-setting-buttons) !important;
 }
 /*note transparent background to make it like shadow*/
 body .content,
@@ -3324,9 +2867,9 @@ body.isWeb.isEnabledBackgroundGradient .ScheduledRepeatProjection {
   background-color: var(--color-background-planner-task) !important;
 }
 /*Github links*/
-a[href] {
+/* a[href] {
   color: var(--color-accent) !important;
-}
+} */
 /*Note colors*/
 body .note,
 body.isDarkTheme .note body.isDarkTheme.isDisableBackgroundGradient .note,
@@ -3391,18 +2934,12 @@ body.isDisableBackgroundGradient
   .panel-content-wrapper
   inline-markdown
   .markdown-unparsed,
-body.isDisableBackgroundGradient
-  .panel-content-wrapper
-  inline-markdown
-  .markdown-parsed,
+body.isDisableBackgroundGradient .panel-content-wrapper inline-markdown .markdown-parsed,
 body.isEnabledBackgroundGradient
   .panel-content-wrapper
   inline-markdown
   .markdown-unparsed,
-body.isEnabledBackgroundGradient
-  .panel-content-wrapper
-  inline-markdown
-  .markdown-parsed,
+body.isEnabledBackgroundGradient .panel-content-wrapper inline-markdown .markdown-parsed,
 body.isLightTheme .panel-content-wrapper inline-markdown .markdown-unparsed,
 body.isLightTheme .panel-content-wrapper inline-markdown .markdown-parsed,
 body.isLightTheme.isDisableBackgroundGradient
@@ -3434,17 +2971,13 @@ body.isWeb.isEnabledBackgroundGradient
 /*provider buttons*/
 body .mat-mdc-raised-button:not(:disabled),
 body.isDarkTheme .mat-mdc-raised-button:not(:disabled),
-body.isDarkTheme.isEnabledBackgroundGradient
-  .mat-mdc-raised-button:not(:disabled),
-body.isDarkTheme.isDisableBackgroundGradient
-  .mat-mdc-raised-button:not(:disabled),
+body.isDarkTheme.isEnabledBackgroundGradient .mat-mdc-raised-button:not(:disabled),
+body.isDarkTheme.isDisableBackgroundGradient .mat-mdc-raised-button:not(:disabled),
 body.isDisableBackgroundGradient .mat-mdc-raised-button:not(:disabled),
 body.isEnabledBackgroundGradient .mat-mdc-raised-button:not(:disabled),
 body.isLightTheme .mat-mdc-raised-button:not(:disabled),
-body.isLightTheme.isEnabledBackgroundGradient
-  .mat-mdc-raised-button:not(:disabled),
-body.isLightTheme.isDisableBackgroundGradient
-  .mat-mdc-raised-button:not(:disabled),
+body.isLightTheme.isEnabledBackgroundGradient .mat-mdc-raised-button:not(:disabled),
+body.isLightTheme.isDisableBackgroundGradient .mat-mdc-raised-button:not(:disabled),
 body.isMac.isEnabledBackgroundGradient .mat-mdc-raised-button:not(:disabled),
 body.isWeb.isEnabledBackgroundGradient .mat-mdc-raised-button:not(:disabled) {
   background-color: var(--color-background-setting-buttons) !important;
@@ -3471,42 +3004,6 @@ body.isDarkTheme.isDisableBackgroundGradient .input-item.standard-size,
 body.isDisableBackgroundGradient .input-item.standard-size,
 body.isEnabledBackgroundGradient .input-item.standard-size {
   background: var(--color-background-task) !important;
-}
-/*hover right sidebar button color*/
-body .isNoTouchOnly.isDarkTheme .input-item.standard-size:hover,
-body.isDarkTheme .isNoTouchOnly .input-item.standard-size:hover,
-body.isDarkTheme .input-item.standard-size:hover,
-body.isDarkTheme.isDisableBackgroundGradient
-  .isNoTouchOnly
-  .input-item.standard-size:hover,
-body.isDarkTheme.isDisableBackgroundGradient .input-item.standard-size:hover,
-body.isDisableBackgroundGradient .isNoTouchOnly .input-item.standard-size:hover,
-body.isDisableBackgroundGradient .input-item.standard-size:hover,
-body.isEnabledBackgroundGradient .isNoTouchOnly .input-item.standard-size:hover,
-body.isEnabledBackgroundGradient .input-item.standard-size:hover,
-body.isLightTheme .isNoTouchOnly .input-item.standard-size:hover,
-body.isLightTheme .input-item.standard-size:hover,
-body.isLightTheme.isDisableBackgroundGradient
-  .isNoTouchOnly
-  .input-item.standard-size:hover,
-body.isLightTheme.isDisableBackgroundGradient .input-item.standard-size:hover,
-body.isMac.isEnabledBackgroundGradient
-  .isNoTouchOnly
-  .input-item.standard-size:hover,
-body.isMac.isEnabledBackgroundGradient .input-item.standard-size:hover {
-  background: var(--color-accent) !important;
-  border-bottom-color: var(--color-accent) !important;
-}
-/*this task-title border color*/
-body .task-title.is-focused,
-body.isDarkTheme .task-title.is-focused,
-body.isDarkTheme.isDisableBackgroundGradient .task-title.is-focused,
-body.isDisableBackgroundGradient .task-title.is-focused,
-body.isEnabledBackgroundGradient .task-title.is-focused,
-body.isLightTheme .task-title.is-focused,
-body.isLightTheme.isDisableBackgroundGradient .task-title.is-focused,
-body.isMac.isEnabledBackgroundGradient .task-title.is-focused {
-  border: 1px solid var(--color-accent) !important;
 }
 /*calendar days background color*/
 body .days,
@@ -3649,43 +3146,6 @@ body.isWeb.isEnabledBackgroundGradient .mat-card {
   body.isMac.isEnabledBackgroundGradient .cdk-drag,
   body.isWeb.isEnabledBackgroundGradient .cdk-drag {
     background: var(--color-background-task) !important;
-  }
-  /* checkbox background color*/
-  body .mdc-checkbox__background,
-  body.isDarkTheme .mdc-checkbox__background,
-  body.isDarkTheme.isDisableBackgroundGradient .mdc-checkbox__background,
-  body.isDisableBackgroundGradient .mdc-checkbox__background,
-  body.isEnabledBackgroundGradient .mdc-checkbox__background,
-  body.isLightTheme .mdc-checkbox__background,
-  body.isLightTheme.isDisableBackgroundGradient .mdc-checkbox__background,
-  body.isMac.isEnabledBackgroundGradient .mdc-checkbox__background,
-  body.isWeb.isEnabledBackgroundGradient
-    .mdc-checkbox__background
-    body
-    .mat-checkbox-checked
-    .mat-checkbox-background,
-  body.isDarkTheme .mat-checkbox-checked .mat-checkbox-background,
-  body.isDarkTheme.isDisableBackgroundGradient
-    .mat-checkbox-checked
-    .mat-checkbox-background,
-  body.isDisableBackgroundGradient
-    .mat-checkbox-checked
-    .mat-checkbox-background,
-  body.isEnabledBackgroundGradient
-    .mat-checkbox-checked
-    .mat-checkbox-background,
-  body.isLightTheme .mat-checkbox-checked .mat-checkbox-background,
-  body.isLightTheme.isDisableBackgroundGradient
-    .mat-checkbox-checked
-    .mat-checkbox-background,
-  body.isMac.isEnabledBackgroundGradient
-    .mat-checkbox-checked
-    .mat-checkbox-background,
-  body.isWeb.isEnabledBackgroundGradient
-    .mat-checkbox-checked
-    .mat-checkbox-background {
-    background-color: var(--color-accent) !important;
-    border-color: var(--color-accent) !important;
   }
   /*repeat task config background color*/
   body .repeat-task-cfg,


### PR DESCRIPTION
Use `!important` workaround on color-accent to be able to fix issue.
Update stopwatch button styles to use accent color and remove redundant selectors.
Clean up hover and checkbox color overrides.

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
